### PR TITLE
create Subject (Observer pattern) for DAS* solvers

### DIFF
--- a/pydas/daspk.pxd
+++ b/pydas/daspk.pxd
@@ -3,7 +3,9 @@ cimport numpy as np
 
 cimport cython
 
-cdef class DASPK:
+from pydas.observer cimport Subject
+ 
+cdef class DASPK(Subject):
 
     cdef public int maxOrder
     cdef public object tstop

--- a/pydas/daspk.pyx
+++ b/pydas/daspk.pyx
@@ -52,6 +52,8 @@ cimport numpy as np
 
 cimport cython
 
+from pydas.observer cimport Subject
+
 ################################################################################
 
 # Expose the (double-precision) DASPK function
@@ -81,6 +83,8 @@ cdef extern from "daspk.h":
 
 ################################################################################
 
+
+
 class DASPKError(Exception):
     """
     An exception class for exceptions relating to use of DASPK.
@@ -93,7 +97,7 @@ class DASPKError(Exception):
         return self.msg
 
 ################################################################################
-cdef class DASPK:
+cdef class DASPK(Subject):
     """
     A base class for using the DASPK differential algebraic system solver by
     L. R. Petzold. DASPK can be used to solve systems of the form
@@ -128,6 +132,7 @@ cdef class DASPK:
     """
     
     def __init__(self, maxOrder=5, initialStep=0, maximumStep=0, tstop=None, bandwidths=None, nonnegative=False, sensitivity=False, sensmethod=0):
+        Subject.__init__(self)
         self.maxOrder = maxOrder
         self.initialStep = initialStep
         self.maximumStep = maximumStep

--- a/pydas/dassl.pxd
+++ b/pydas/dassl.pxd
@@ -3,7 +3,9 @@ cimport numpy as np
 
 cimport cython
 
-cdef class DASSL:
+from pydas.observer cimport Subject
+
+cdef class DASSL(Subject):
 
     cdef public int maxOrder
     cdef public object tstop

--- a/pydas/dassl.pyx
+++ b/pydas/dassl.pyx
@@ -52,6 +52,7 @@ cimport numpy as np
 
 cimport cython
 
+from pydas.observer cimport Subject
 ################################################################################
 
 # Expose the (double-precision) DASSL function
@@ -91,7 +92,7 @@ class DASSLError(Exception):
 
 ################################################################################
 
-cdef class DASSL:
+cdef class DASSL(Subject):
     """
     A base class for using the DASSL differential algebraic system solver by
     L. R. Petzold. DASSL can be used to solve systems of the form
@@ -126,6 +127,7 @@ cdef class DASSL:
 
     
     def __init__(self, maxOrder=5, initialStep=0, maximumStep=0, tstop=None, bandwidths=None, nonnegative=False, **kwargs):
+        Subject.__init__(self)
         self.maxOrder = maxOrder
         self.initialStep = initialStep
         self.maximumStep = maximumStep

--- a/pydas/observer.pxd
+++ b/pydas/observer.pxd
@@ -1,0 +1,9 @@
+cdef class Subject:
+    
+    cdef public object _observers
+
+    cpdef attach(self, object observer)
+
+    cpdef detach(self, object observer)
+
+    cpdef notify(self, object modifier=?)

--- a/pydas/observer.pyx
+++ b/pydas/observer.pyx
@@ -3,16 +3,70 @@ cdef class Subject:
     def __init__(self):
         self._observers = []
 
+    """
+    Call this method when your (self-implemented)
+    observer class should start listening to the Subject
+    class.
+
+    e.g.:
+
+    listener = YourOwnListener()
+    subject.attach(listener)
+    """
     cpdef attach(self, observer):
         if not observer in self._observers:
             self._observers.append(observer)
 
+
+    """
+    Call this method when your (self-implemented)
+    observer class should stop listening to the Subject
+    class.
+
+    e.g.:
+    listener = YourOwnListener()
+    subject.attach(listener)
+
+    ...<do some work>...
+
+    subject.detach(listener)
+
+    """
     cpdef detach(self, observer):
         try:
             self._observers.remove(observer)
         except ValueError:
             pass
 
+    """
+    Call this method in classes that implement
+    Subject, when the data that your interested in,
+    is available.
+
+    e.g.:
+    class ReactionSystem(...):
+        ...
+        def simulate(...)
+            <stuff is being done>
+
+            self.notify()
+
+            <continue doing other stuff>            
+
+
+    Make sure that your listener class implements the update(subject)
+    method!
+
+    e.g.:
+
+    class YourOwnListener(object):
+        def __init__(self):
+            self.data = []
+
+        def update(self, subject):
+            self.data.append(subject.data)
+
+    """
     cpdef notify(self, modifier=None):
         for observer in self._observers:
             if modifier != observer:

--- a/pydas/observer.pyx
+++ b/pydas/observer.pyx
@@ -1,0 +1,19 @@
+cdef class Subject:
+    """Subject in Observer Pattern"""
+    def __init__(self):
+        self._observers = []
+
+    cpdef attach(self, observer):
+        if not observer in self._observers:
+            self._observers.append(observer)
+
+    cpdef detach(self, observer):
+        try:
+            self._observers.remove(observer)
+        except ValueError:
+            pass
+
+    cpdef notify(self, modifier=None):
+        for observer in self._observers:
+            if modifier != observer:
+                observer.update(self)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ if __name__ == '__main__':
     Cython.Compiler.Options.annotate = True
     
     # The Cython extension modules to compile
+    observer_ext = Extension(
+            'pydas.observer', 
+            ['pydas/observer.pyx'], 
+            include_dirs=['pydas'], 
+        )
+
     pydas_ext = Extension(
             'pydas.dassl', 
             ['pydas/dassl.pyx'], 
@@ -63,10 +69,10 @@ if __name__ == '__main__':
             libraries=['gfortran'], 
             extra_objects=['daspk31/solver/adf_dummy.o','daspk31/solver/daux.o','daspk31/solver/ddaspk.o','daspk31/solver/dlinpk.o','daspk31/solver/dsensd.o','daspk31/solver/mpi_dummy.o'],
         )
-    
 
-    modules = ['pydas.dassl']
-    extensions = [pydas_ext]
+
+    modules = ['pydas.dassl', 'pydas.observer']
+    extensions = [pydas_ext, observer_ext]
 
     if 'daspk' in sys.argv:
         # Optionally compile and make pydaspk if the user requests it


### PR DESCRIPTION
By subclassing to the Subject class, one can easily extract temporary state variables of the ReactionSystem classes (SimpleReactor, Liquid...).

For example, I am interested in the species concentrations when `solve` is called.

**Step 1**

add `self.notify()` at the location in the `solve` method reactor implementation where you are sure the species concentrations are available. For example here: 

https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/rmgpy/solver/base.pyx#L219

**Step 2**
Write a listener class that will store the data you are interested in, e.g. `ConcentrationListener`.

``` python
class ConcentrationListener(object):
    def __init__(self):
        self.data = []

    def update(self, subject):
        self.data.append(subject.coreSpeciesConcentrations)
```

Next, in your client code, create an instance of the listener, attach the listener to the Reactor model, call the Reactor method that will generate the data you are interested, and detach the listener when you have collected the data:

``` python
def client_code(...):
    #create a listener instance:
    listener = ConcentrationListener()

    reactionSystem.attach(listener)

    terminated, obj = reactionSystem.simulate(
...
    ) 

    #unregister as a listener
    reactionSystem.detach(listener) 
```

This pattern:
- avoids having to write/read to disk to access temporary state variables of the Reactor Models, and (which is done for sensitivity info right now) that are not stored as object attributes.
- Almost nothing is modified in the original code (only 1 call `self.notify()`) and it loosely coupled 
- various types of listeners can be created, while the Reactor model code is agnostic of the type of data one is collecting.
